### PR TITLE
Update Gradle Wrapper from 8.12 to 8.12.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7ebdac923867a3cec0098302416d1e3c6c0c729fc4e2e05c10637a8af33a76c5
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionSha256Sum=296742a352f0b20ec14b143fb684965ad66086c7810b7b255dee216670716175
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update Gradle Wrapper from 8.12 to 8.12.1.

Read the release notes: https://docs.gradle.org/8.12.1/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `8.12.1`
- Distribution (-all) zip checksum: `296742a352f0b20ec14b143fb684965ad66086c7810b7b255dee216670716175`
- Wrapper JAR Checksum: `2db75c40782f5e8ba1fc278a5574bab070adccb2d21ca5a6e5ed840888448046`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Gradle wrapper to version 8.12.1
	- Updated Gradle distribution checksum for security and integrity purposes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->