### PR TITLE
Update client to `v0.3.1`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,22 +1,19 @@
 [versions]
 
-catFactClient = "0.2.0"
+catFactClient = "0.3.1"
 coroutines = "1.10.1"
 honeycomb = "1.7.0"
 jacoco = "0.8.7"
-jooq = "0.9.15"
 jooq_docker_plugin = "0.3.9"
 jvmTarget = "17"
 kotlin = "2.1.0"
 mockk = "1.13.16"
 mockkSpring = "4.0.2"
 postgres = "42.7.4"
-pwd = "6.42.0"
 spotless = "6.25.0"
 spring_dependency_management = "1.1.0"
 springboot = "3.1.0"
 springdoc = "2.6.0"
-swagger = "6.6.0"
 testcontainers = "1.20.4"
 
 [libraries]

--- a/src/main/kotlin/com/yonatankarp/cat/fact/service/config/ApplicationConfiguration.kt
+++ b/src/main/kotlin/com/yonatankarp/cat/fact/service/config/ApplicationConfiguration.kt
@@ -1,11 +1,11 @@
 package com.yonatankarp.cat.fact.service.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.yonatankarp.cat.fact.client.ports.CatFactFactory
+import com.yonatankarp.cat.fact.client.ports.CatFactProvider
+import com.yonatankarp.cat.fact.client.ports.ProviderType
 import com.yonatankarp.cat.fact.service.request.RequestContext
 import com.yonatankarp.cat.fact.service.request.RequestContextImpl
-import com.yonatankarpcat.fact.client.ports.CatFactFactory
-import com.yonatankarpcat.fact.client.ports.CatFactProvider
-import com.yonatankarpcat.fact.client.ports.ProviderType
 import kotlinx.coroutines.runBlocking
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/com/yonatankarp/cat/fact/service/controllers/CatFactController.kt
+++ b/src/main/kotlin/com/yonatankarp/cat/fact/service/controllers/CatFactController.kt
@@ -1,8 +1,8 @@
 package com.yonatankarp.cat.fact.service.controllers
 
+import com.yonatankarp.cat.fact.client.ports.Fact
 import com.yonatankarp.cat.fact.service.request.RequestContext
 import com.yonatankarp.cat.fact.service.service.CatFactService
-import com.yonatankarpcat.fact.client.ports.Fact
 import org.springframework.http.ResponseEntity
 import org.springframework.http.ResponseEntity.ok
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/com/yonatankarp/cat/fact/service/repository/CatFactRepository.kt
+++ b/src/main/kotlin/com/yonatankarp/cat/fact/service/repository/CatFactRepository.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.cat.fact.service.repository
 
-import com.yonatankarpcat.fact.client.ports.Fact
+import com.yonatankarp.cat.fact.client.ports.Fact
 import org.jooq.DSLContext
 import org.jooq.generated.Tables
 import org.springframework.stereotype.Repository

--- a/src/main/kotlin/com/yonatankarp/cat/fact/service/request/RequestContext.kt
+++ b/src/main/kotlin/com/yonatankarp/cat/fact/service/request/RequestContext.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.cat.fact.service.request
 
-import com.yonatankarpcat.fact.client.ports.Fact
+import com.yonatankarp.cat.fact.client.ports.Fact
 
 /**
  * Provides random amount of facts about cats into the request context.

--- a/src/main/kotlin/com/yonatankarp/cat/fact/service/service/CatFactService.kt
+++ b/src/main/kotlin/com/yonatankarp/cat/fact/service/service/CatFactService.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.cat.fact.service.service
 
+import com.yonatankarp.cat.fact.client.ports.Fact
 import com.yonatankarp.cat.fact.service.repository.CatFactRepository
-import com.yonatankarpcat.fact.client.ports.Fact
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/test/kotlin/com/yonatankarp/cat/fact/service/CatFactServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/yonatankarp/cat/fact/service/CatFactServiceIntegrationTest.kt
@@ -1,10 +1,9 @@
 package com.yonatankarp.cat.fact.service
 
 import com.ninjasquad.springmockk.MockkBean
-import com.yonatankarpcat.fact.client.ports.CatFactProvider
-import com.yonatankarpcat.fact.client.ports.Fact
+import com.yonatankarp.cat.fact.client.ports.CatFactProvider
+import com.yonatankarp.cat.fact.client.ports.Fact
 import io.mockk.coEvery
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.jooq.DSLContext
 import org.jooq.generated.Tables
@@ -18,11 +17,11 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.testcontainers.junit.jupiter.Testcontainers
+import kotlin.time.Duration.Companion.seconds
 
 @SpringBootTest
 @Testcontainers
 @TestConstructor(autowireMode = AutowireMode.ALL)
-@OptIn(ExperimentalCoroutinesApi::class)
 @AutoConfigureMockMvc
 class CatFactServiceIntegrationTest(
     private val mockMvc: MockMvc,
@@ -32,8 +31,8 @@ class CatFactServiceIntegrationTest(
     private lateinit var provider: CatFactProvider
 
     @Test
-    fun `should fetch facts and store them correctly in the database`() =
-        runTest {
+    fun `should fetch facts and store them correctly in the database`(): Unit =
+        runTest(timeout = 5.seconds) {
             // Given facts
             val catFact = "fact about cat..."
             coEvery { provider.get(any()) } returns setOf(Fact(catFact))

--- a/src/test/kotlin/com/yonatankarp/cat/fact/service/controllers/CatFactControllerTest.kt
+++ b/src/test/kotlin/com/yonatankarp/cat/fact/service/controllers/CatFactControllerTest.kt
@@ -1,12 +1,11 @@
 package com.yonatankarp.cat.fact.service.controllers
 
 import com.ninjasquad.springmockk.MockkBean
+import com.yonatankarp.cat.fact.client.ports.Fact
 import com.yonatankarp.cat.fact.service.request.RequestContext
 import com.yonatankarp.cat.fact.service.service.CatFactService
-import com.yonatankarpcat.fact.client.ports.Fact
 import io.mockk.coEvery
 import io.mockk.coVerify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -19,8 +18,9 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalStdlibApi::class)
+// @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(SpringExtension::class)
 @WebMvcTest(controllers = [CatFactController::class])
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -35,7 +35,7 @@ class CatFactControllerTest(
 
     @Test
     fun `should serve default amount of facts`() =
-        runTest {
+        runTest(timeout = 1.seconds) {
             coEvery { service.storeFacts(any()) } returns Unit
             coEvery { requestContext.facts } returns setOf(Fact("fact about cat..."))
 
@@ -57,7 +57,7 @@ class CatFactControllerTest(
     @ParameterizedTest
     @MethodSource("getData")
     fun `should serve custom amount of facts`(amountOfFacts: Int) =
-        runTest {
+        runTest(timeout = 1.seconds) {
             coEvery { service.storeFacts(any()) } returns Unit
             coEvery { requestContext.facts } returns (1..amountOfFacts).map { Fact("Fact $it") }.toSet()
 

--- a/src/test/kotlin/com/yonatankarp/cat/fact/service/service/CatFactServiceTest.kt
+++ b/src/test/kotlin/com/yonatankarp/cat/fact/service/service/CatFactServiceTest.kt
@@ -1,16 +1,15 @@
 package com.yonatankarp.cat.fact.service.service
 
+import com.yonatankarp.cat.fact.client.ports.Fact
 import com.yonatankarp.cat.fact.service.repository.CatFactRepository
-import com.yonatankarpcat.fact.client.ports.Fact
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.TestConstructor
+import kotlin.time.Duration.Companion.milliseconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class CatFactServiceTest {
     private val repository: CatFactRepository = mockk<CatFactRepository>()
@@ -18,7 +17,7 @@ class CatFactServiceTest {
 
     @Test
     fun `should store facts to repository`() =
-        runTest {
+        runTest(timeout = 500.milliseconds) {
             // Given
             val facts = setOf(Fact("fact1"), Fact("fact2"))
             coEvery { repository.storeFacts(any()) } returns true


### PR DESCRIPTION

# Purpose

This commit updates the cat fact client to version `0.3.1`, which contains some breaking changes in the location of the files, no business-logic functionality was changed in this commit.

# Types of changes

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected several import statement typos and formatting issues to ensure proper loading of dependencies and classes throughout the application and tests.
  * Removed unnecessary experimental API usage and updated coroutine test invocations to include explicit timeouts for improved test reliability.

* **Chores**
  * Updated the version of an external dependency to the latest release and cleaned up unused version entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->